### PR TITLE
fix: delete input .txt files after processing and zipping

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -75,7 +75,12 @@ public class Main {
 
         zipTimer.printElapsed("Zip oluşturma süresi");
 
-        // 6. Toplam süre
+        // 6. Dosyaları sil
+        System.out.println("\n==> Analiz tamamlandı. .txt dosyaları siliniyor...");
+        FileUtils.deleteTxtFiles(txtFilePaths);
+        System.out.println("==> Silme işlemi tamamlandı.");
+
+        // 7. Toplam süre
         totalTimer.printElapsed("Toplam çalışma süresi");
     }
 }


### PR DESCRIPTION
After all analysis and zip operations complete, the input directory's .txt files are deleted. This cleanup ensures the system doesn't reprocess old files in the next run. Logs are printed for each deletion and a summary log confirms completion.